### PR TITLE
(#49) 🎨 design: 메인홈 반응형 구현

### DIFF
--- a/src/constants/ReactionData.ts
+++ b/src/constants/ReactionData.ts
@@ -1,8 +1,8 @@
 // 화면 크기에 대한 이넘 정의
-export enum ScreenSize {
+export enum ScreenWidthSize {
     SMALL = 360,        // 작은 폰 기종 화면 (360px)
     MEDIUM = 390,       // 일반 폰 기종 화면 (390px)
-    LARGE = 410,        // Pro 폰 기종 화면 (400~410px)
+    LARGE = 400,        // Pro 폰 기종 화면 (400~410px)
     EXTRA_LARGE = 500,  // Web, 패드 등 모바일 이외 전자기기에서 최대 너비 제한 (500px 이상)
 }
 
@@ -14,79 +14,95 @@ export interface ImageSize {
 }
 
 
-export const ImageDimensions: Record<StadiumType, Record<ScreenSize, ImageSize>> = {
+export const ImageDimensions: Record<StadiumType, Record<ScreenWidthSize, ImageSize>> = {
     [StadiumType.JAMSIL]: {
-        [ScreenSize.SMALL]: { width: 337, height: 319 },
-        [ScreenSize.MEDIUM]: { width: 350, height: 331 },
-        [ScreenSize.LARGE]: { width: 376, height: 356 },
-        [ScreenSize.EXTRA_LARGE]: { width: 376, height: 356 },
+        [ScreenWidthSize.SMALL]: { width: 337, height: 319 },
+        [ScreenWidthSize.MEDIUM]: { width: 350, height: 331 },
+        [ScreenWidthSize.LARGE]: { width: 376, height: 356 },
+        [ScreenWidthSize.EXTRA_LARGE]: { width: 376, height: 356 },
     },
     [StadiumType.SUWON_KT]: {
-        [ScreenSize.SMALL]: { width: 316, height: 345 },
-        [ScreenSize.MEDIUM]: { width: 343, height: 374 },
-        [ScreenSize.LARGE]: { width: 366, height: 400 },
-        [ScreenSize.EXTRA_LARGE]: { width: 366, height: 400 },
+        [ScreenWidthSize.SMALL]: { width: 316, height: 345 },
+        [ScreenWidthSize.MEDIUM]: { width: 343, height: 374 },
+        [ScreenWidthSize.LARGE]: { width: 366, height: 400 },
+        [ScreenWidthSize.EXTRA_LARGE]: { width: 366, height: 400 },
     },
 
 
     ///// 제공하지 않는 이미지라서 임시적으로 width, height 모두 0으로 했음
     [StadiumType.GOCHEOK_SKY_DOME]: {
-        [ScreenSize.SMALL]: { width: 0, height: 0 },
-        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
-        [ScreenSize.LARGE]: { width: 0, height: 0 },
-        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.SMALL]: { width: 0, height: 0 },
+        [ScreenWidthSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenWidthSize.LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.EXTRA_LARGE]: { width: 0, height: 0 },
     },
     [StadiumType.KIA_CHAMPIONS_FIELD]: {
-        [ScreenSize.SMALL]: { width: 0, height: 0 },
-        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
-        [ScreenSize.LARGE]: { width: 0, height: 0 },
-        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.SMALL]: { width: 0, height: 0 },
+        [ScreenWidthSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenWidthSize.LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.EXTRA_LARGE]: { width: 0, height: 0 },
     },
     [StadiumType.SAMSUNG_LIONS_PARK]: {
-        [ScreenSize.SMALL]: { width: 0, height: 0 },
-        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
-        [ScreenSize.LARGE]: { width: 0, height: 0 },
-        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.SMALL]: { width: 0, height: 0 },
+        [ScreenWidthSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenWidthSize.LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.EXTRA_LARGE]: { width: 0, height: 0 },
     },
     [StadiumType.HANWHA_EAGLES_PARK]: {
-        [ScreenSize.SMALL]: { width: 0, height: 0 },
-        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
-        [ScreenSize.LARGE]: { width: 0, height: 0 },
-        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.SMALL]: { width: 0, height: 0 },
+        [ScreenWidthSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenWidthSize.LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.EXTRA_LARGE]: { width: 0, height: 0 },
     },
     [StadiumType.LOTTE_GIANTS_PARK]: {
-        [ScreenSize.SMALL]: { width: 0, height: 0 },
-        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
-        [ScreenSize.LARGE]: { width: 0, height: 0 },
-        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.SMALL]: { width: 0, height: 0 },
+        [ScreenWidthSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenWidthSize.LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.EXTRA_LARGE]: { width: 0, height: 0 },
     },
     [StadiumType.SSG_LENDERS_FIELD]: {
-        [ScreenSize.SMALL]: { width: 0, height: 0 },
-        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
-        [ScreenSize.LARGE]: { width: 0, height: 0 },
-        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.SMALL]: { width: 0, height: 0 },
+        [ScreenWidthSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenWidthSize.LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.EXTRA_LARGE]: { width: 0, height: 0 },
     },
     [StadiumType.CHANDWON_NC_PARK]: {
-        [ScreenSize.SMALL]: { width: 0, height: 0 },
-        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
-        [ScreenSize.LARGE]: { width: 0, height: 0 },
-        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.SMALL]: { width: 0, height: 0 },
+        [ScreenWidthSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenWidthSize.LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.EXTRA_LARGE]: { width: 0, height: 0 },
     },
     // 이미 존재하는 stadium 타입들도 그대로 두고, 'NONE'에 대해서만 0 값을 지정
     [StadiumType.NONE]: {
-        [ScreenSize.SMALL]: { width: 0, height: 0 },
-        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
-        [ScreenSize.LARGE]: { width: 0, height: 0 },
-        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.SMALL]: { width: 0, height: 0 },
+        [ScreenWidthSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenWidthSize.LARGE]: { width: 0, height: 0 },
+        [ScreenWidthSize.EXTRA_LARGE]: { width: 0, height: 0 },
     },
 };
 
+
+// 화면 너비를 기반으로 ScreenWidthSize 결정하는 함수
+// 파라미터로 받은 width가 SMALL이랑 같거나 작으면 SMALL, SMALL보다 크고 LARGE보다 작으면 MEDIUM, LARGE 이상은 LARGE를 기준으로 width, height 값을 주는 로직으로 수정해줘
+const getScreenWidthSizeFromWindow = (width: number): ScreenWidthSize => {
+    if (width <= ScreenWidthSize.SMALL) {
+        return ScreenWidthSize.SMALL;
+    } else if (width > ScreenWidthSize.SMALL && width < ScreenWidthSize.LARGE) {
+        return ScreenWidthSize.MEDIUM;
+    } else {
+        return ScreenWidthSize.LARGE;
+    }
+};
+
 // 이미지 크기를 각각의 width와 height로 반환하는 함수
-export const getImageDimensions = (stadiumName: StadiumType, screenSize: ScreenSize): ImageSize => {
-    const dimensions = ImageDimensions[stadiumName]?.[screenSize];
+export const getImageDimensions = (stadiumName: StadiumType, windowWidth: number): ImageSize => {
+    const screenWidthSize = getScreenWidthSizeFromWindow(windowWidth);
+    const dimensions = ImageDimensions[stadiumName]?.[screenWidthSize];
+    
     if (dimensions) {
         return { width: dimensions.width, height: dimensions.height };
     } else {
         return { width: 0, height: 0 }; // 기본값
     }
 };
+

--- a/src/constants/ReactionData.ts
+++ b/src/constants/ReactionData.ts
@@ -1,0 +1,7 @@
+// 화면 크기에 대한 이넘 정의
+export enum ScreenSize {
+    SMALL = 360,        // 작은 폰 기종 화면 (360px)
+    MEDIUM = 390,       // 일반 폰 기종 화면 (390px)
+    LARGE = 410,        // Pro 폰 기종 화면 (400~410px)
+    EXTRA_LARGE = 500,  // Web, 패드 등 모바일 이외 전자기기에서 최대 너비 제한 (500px 이상)
+  }

--- a/src/constants/ReactionData.ts
+++ b/src/constants/ReactionData.ts
@@ -4,4 +4,89 @@ export enum ScreenSize {
     MEDIUM = 390,       // 일반 폰 기종 화면 (390px)
     LARGE = 410,        // Pro 폰 기종 화면 (400~410px)
     EXTRA_LARGE = 500,  // Web, 패드 등 모바일 이외 전자기기에서 최대 너비 제한 (500px 이상)
-  }
+}
+
+// 화면 크기별 너비와 높이를 하나의 객체로 통합하여 관리
+import { StadiumType } from "./ZoneData";
+export interface ImageSize {
+    width: number;
+    height: number;
+}
+
+
+export const ImageDimensions: Record<StadiumType, Record<ScreenSize, ImageSize>> = {
+    [StadiumType.JAMSIL]: {
+        [ScreenSize.SMALL]: { width: 337, height: 319 },
+        [ScreenSize.MEDIUM]: { width: 350, height: 331 },
+        [ScreenSize.LARGE]: { width: 376, height: 356 },
+        [ScreenSize.EXTRA_LARGE]: { width: 376, height: 356 },
+    },
+    [StadiumType.SUWON_KT]: {
+        [ScreenSize.SMALL]: { width: 316, height: 345 },
+        [ScreenSize.MEDIUM]: { width: 343, height: 374 },
+        [ScreenSize.LARGE]: { width: 366, height: 400 },
+        [ScreenSize.EXTRA_LARGE]: { width: 366, height: 400 },
+    },
+
+
+    ///// 제공하지 않는 이미지라서 임시적으로 width, height 모두 0으로 했음
+    [StadiumType.GOCHEOK_SKY_DOME]: {
+        [ScreenSize.SMALL]: { width: 0, height: 0 },
+        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenSize.LARGE]: { width: 0, height: 0 },
+        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+    },
+    [StadiumType.KIA_CHAMPIONS_FIELD]: {
+        [ScreenSize.SMALL]: { width: 0, height: 0 },
+        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenSize.LARGE]: { width: 0, height: 0 },
+        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+    },
+    [StadiumType.SAMSUNG_LIONS_PARK]: {
+        [ScreenSize.SMALL]: { width: 0, height: 0 },
+        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenSize.LARGE]: { width: 0, height: 0 },
+        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+    },
+    [StadiumType.HANWHA_EAGLES_PARK]: {
+        [ScreenSize.SMALL]: { width: 0, height: 0 },
+        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenSize.LARGE]: { width: 0, height: 0 },
+        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+    },
+    [StadiumType.LOTTE_GIANTS_PARK]: {
+        [ScreenSize.SMALL]: { width: 0, height: 0 },
+        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenSize.LARGE]: { width: 0, height: 0 },
+        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+    },
+    [StadiumType.SSG_LENDERS_FIELD]: {
+        [ScreenSize.SMALL]: { width: 0, height: 0 },
+        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenSize.LARGE]: { width: 0, height: 0 },
+        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+    },
+    [StadiumType.CHANDWON_NC_PARK]: {
+        [ScreenSize.SMALL]: { width: 0, height: 0 },
+        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenSize.LARGE]: { width: 0, height: 0 },
+        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+    },
+    // 이미 존재하는 stadium 타입들도 그대로 두고, 'NONE'에 대해서만 0 값을 지정
+    [StadiumType.NONE]: {
+        [ScreenSize.SMALL]: { width: 0, height: 0 },
+        [ScreenSize.MEDIUM]: { width: 0, height: 0 },
+        [ScreenSize.LARGE]: { width: 0, height: 0 },
+        [ScreenSize.EXTRA_LARGE]: { width: 0, height: 0 },
+    },
+};
+
+// 이미지 크기를 각각의 width와 height로 반환하는 함수
+export const getImageDimensions = (stadiumName: StadiumType, screenSize: ScreenSize): ImageSize => {
+    const dimensions = ImageDimensions[stadiumName]?.[screenSize];
+    if (dimensions) {
+        return { width: dimensions.width, height: dimensions.height };
+    } else {
+        return { width: 0, height: 0 }; // 기본값
+    }
+};

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -90,9 +90,9 @@ const Main = ({ selectedStadium, setSelectedStadium }: Props) => {
         {/* 야구장 좌석 이미지 선택 */}
         <div className="mt-4 flex justify-center">
           {selectedStadium === StadiumType.JAMSIL ? (
-            <JamsilSeat />
+            <JamsilSeat screenWidth={window.innerWidth} />
           ) : selectedStadium === StadiumType.SUWON_KT ? (
-            <KtwizSeat />
+            <KtwizSeat screenWidth={window.innerWidth} />
           ) : (
             <p className="text-grayscale-90">해당 구장은 추후 업데이트 예정입니다 :)</p>
           )}

--- a/src/pages/Main/components/JamsilSeat.tsx
+++ b/src/pages/Main/components/JamsilSeat.tsx
@@ -11,7 +11,9 @@ import tableStadium from "../../../assets/webp/seat/jamsil_table.webp";
 import premiumStadium from "../../../assets/webp/seat/jamsil_premium.webp";
 import greenStadium from "../../../assets/webp/seat/jamsil_green.webp";
 import excitingStadium from "../../../assets/webp/seat/jamsil_exciting.webp";
-import { ScreenSize } from "@/src/constants/ReactionData"
+
+import { StadiumType } from "@/src/constants/ZoneData";
+import { getImageDimensions } from "@/src/constants/ReactionData"
 
 // 각 색상별 이미지와 오차값 포함
 const colorMap: { [key: string]: { image: StaticImageData; tolerance: number } } = {
@@ -66,8 +68,8 @@ const JamsilSeat = ({ screenWidth }: Props) => {
         const ctx = canvas.getContext("2d");
         const scale = window.devicePixelRatio || 1;  // 화면 배율에 따른 픽셀 밀도 조절
 
-        const canvasWidth = 376;
-        const canvasHeight = 356;
+        const canvasWidth = getImageDimensions(StadiumType.JAMSIL, screenWidth).width;
+        const canvasHeight = getImageDimensions(StadiumType.JAMSIL, screenWidth).height;
         canvas.width = canvasWidth * scale;
         canvas.height = canvasHeight * scale;
 
@@ -138,7 +140,7 @@ const JamsilSeat = ({ screenWidth }: Props) => {
     <div className="flex justify-center mt-6" onClick={() => setSeatImage(defaultStadium)}>
       <canvas
         ref={canvasRef}
-        className="w-full max-w-[376px] mx-auto"
+        className={`w-full max-w-[${getImageDimensions(StadiumType.JAMSIL, screenWidth).height}px] mx-auto`}
         onClick={handleCanvasClick}
       />
     </div>

--- a/src/pages/Main/components/JamsilSeat.tsx
+++ b/src/pages/Main/components/JamsilSeat.tsx
@@ -11,6 +11,7 @@ import tableStadium from "../../../assets/webp/seat/jamsil_table.webp";
 import premiumStadium from "../../../assets/webp/seat/jamsil_premium.webp";
 import greenStadium from "../../../assets/webp/seat/jamsil_green.webp";
 import excitingStadium from "../../../assets/webp/seat/jamsil_exciting.webp";
+import { ScreenSize } from "@/src/constants/ReactionData"
 
 // 각 색상별 이미지와 오차값 포함
 const colorMap: { [key: string]: { image: StaticImageData; tolerance: number } } = {

--- a/src/pages/Main/components/JamsilSeat.tsx
+++ b/src/pages/Main/components/JamsilSeat.tsx
@@ -47,7 +47,11 @@ const isColorClose = (
   );
 };
 
-const JamsilSeat = () => {
+interface Props {
+  screenWidth: number;
+};
+
+const JamsilSeat = ({ screenWidth }: Props) => {
   const [seatImage, setSeatImage] = useState<StaticImageData>(defaultStadium);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [isImageLoaded, setIsImageLoaded] = useState(false);

--- a/src/pages/Main/components/KtwizSeat.tsx
+++ b/src/pages/Main/components/KtwizSeat.tsx
@@ -15,7 +15,9 @@ import genieZoneSeat from "../../../assets/webp/seat/kt_geniezone.webp";
 import excitingSeat from "../../../assets/webp/seat/kt_exciting.webp";
 import outfieldSeat from "../../../assets/webp/seat/kt_outfield.webp";
 import tvingSeat from "../../../assets/webp/seat/kt_tving.webp";
-import { ScreenWidthSize } from "@/src/constants/ReactionData"
+
+import { StadiumType } from "@/src/constants/ZoneData";
+import { getImageDimensions } from "@/src/constants/ReactionData"
 
 // 각 색상별 이미지와 오차값 포함
 const colorMap: { [key: string]: { image: StaticImageData; tolerance: number } } = {
@@ -74,8 +76,8 @@ const KtwizSeat = ({ screenWidth }: Props) => {
         const ctx = canvas.getContext("2d");
         const scale = window.devicePixelRatio || 1; // 화면 배율에 따라 픽셀 밀도 조절
 
-        const canvasWidth = 343;
-        const canvasHeight = 374;
+        const canvasWidth = getImageDimensions(StadiumType.SUWON_KT, screenWidth).width;
+        const canvasHeight = getImageDimensions(StadiumType.SUWON_KT, screenWidth).height;
         canvas.width = canvasWidth * scale;
         canvas.height = canvasHeight * scale;
 
@@ -153,7 +155,7 @@ const KtwizSeat = ({ screenWidth }: Props) => {
     <div className="flex justify-center mt-6" onClick={() => setSeatImage(defaultStadium)}>
       <canvas
         ref={canvasRef}
-        className="max-w-[343px] w-full mx-auto"
+        className={`w-full max-w-[${getImageDimensions(StadiumType.SUWON_KT, screenWidth).height}px] mx-auto`}
         onClick={handleCanvasClick}
       />
     </div>

--- a/src/pages/Main/components/KtwizSeat.tsx
+++ b/src/pages/Main/components/KtwizSeat.tsx
@@ -15,7 +15,7 @@ import genieZoneSeat from "../../../assets/webp/seat/kt_geniezone.webp";
 import excitingSeat from "../../../assets/webp/seat/kt_exciting.webp";
 import outfieldSeat from "../../../assets/webp/seat/kt_outfield.webp";
 import tvingSeat from "../../../assets/webp/seat/kt_tving.webp";
-import { ScreenSize } from "@/src/constants/ReactionData"
+import { ScreenWidthSize } from "@/src/constants/ReactionData"
 
 // 각 색상별 이미지와 오차값 포함
 const colorMap: { [key: string]: { image: StaticImageData; tolerance: number } } = {

--- a/src/pages/Main/components/KtwizSeat.tsx
+++ b/src/pages/Main/components/KtwizSeat.tsx
@@ -18,18 +18,18 @@ import tvingSeat from "../../../assets/webp/seat/kt_tving.webp";
 
 // 각 색상별 이미지와 오차값 포함
 const colorMap: { [key: string]: { image: StaticImageData; tolerance: number } } = {
-  "#B23039": { image: cheerSeat, tolerance: 2 },        // 빨간색 좌석: cheerSeat
+  "#B23039": { image: cheerSeat, tolerance: 10 },        // 빨간색 좌석: cheerSeat
   "#65C5DE": { image: skySeat, tolerance: 20 },         // 하늘색 좌석: skySeat
-  "#292F46": { image: skyZoneSeat, tolerance: 20 },     // 남색 좌석: skyZoneSeat
-  "#008FD7": { image: kidsLandSeat, tolerance: 20 },    // 파랑 좌석: kidsLandSeat
+  "#292F46": { image: skyZoneSeat, tolerance: 35 },     // 남색 좌석: skyZoneSeat
+  "#008FD7": { image: kidsLandSeat, tolerance: 30 },    // 파랑 좌석: kidsLandSeat
   "#5E346E": { image: centralSeat, tolerance: 20 },     // 보라색 좌석: centralSeat
   "#599741": { image: genieTvSeat, tolerance: 10 },     // 녹색 좌석: genieTvSeat
   "#F5A545": { image: yboxSeat, tolerance: 10 },        // 주황색 좌석: yboxSeat
-  "#E95560": { image: alphaShoppingSeat, tolerance: 5 }, // 핑크 좌석: alphaShoppingSeat
-  "#35659E": { image: genieZoneSeat, tolerance: 5 },    // 짙은 파랑 좌석: genieZoneSeat
-  "#3EA6A5": { image: excitingSeat, tolerance: 5 },     // 민트 좌석: excitingSeat
-  "#CEDA82": { image: outfieldSeat, tolerance: 20 },    // 연노랑 좌석: outfieldSeat
-  "#E3A3B1": { image: tvingSeat, tolerance: 5 },        // 연분홍 좌석: tvingSeat
+  "#E95560": { image: alphaShoppingSeat, tolerance: 20 }, // 핑크 좌석: alphaShoppingSeat
+  "#35659E": { image: genieZoneSeat, tolerance: 15 },    // 짙은 파랑 좌석: genieZoneSeat
+  "#3EA6A5": { image: excitingSeat, tolerance: 35 },     // 민트 좌석: excitingSeat
+  "#CEDA82": { image: outfieldSeat, tolerance: 30 },    // 연노랑 좌석: outfieldSeat
+  "#E3A3B1": { image: tvingSeat, tolerance: 15 },        // 연분홍 좌석: tvingSeat
 };
 
 // HEX 색상을 RGB로 변환하는 함수
@@ -55,7 +55,11 @@ const isColorClose = (
   );
 };
 
-const KtwizSeat = () => {
+interface Props {
+  screenWidth: number;
+};
+
+const KtwizSeat = ({ screenWidth }: Props) => {
   const [seatImage, setSeatImage] = useState<StaticImageData>(defaultStadium);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [isImageLoaded, setIsImageLoaded] = useState(false);
@@ -69,8 +73,8 @@ const KtwizSeat = () => {
         const ctx = canvas.getContext("2d");
         const scale = window.devicePixelRatio || 1; // 화면 배율에 따라 픽셀 밀도 조절
 
-        const canvasWidth = 366;
-        const canvasHeight = 400;
+        const canvasWidth = 343;
+        const canvasHeight = 374;
         canvas.width = canvasWidth * scale;
         canvas.height = canvasHeight * scale;
 
@@ -124,24 +128,31 @@ const KtwizSeat = () => {
         const [r, g, b] = [pixelData[0], pixelData[1], pixelData[2]];
 
         // 클릭한 색상에 따라 해당 좌석 이미지로 변경
-        let matchedImage = defaultStadium;
-        Object.keys(colorMap).forEach((hex) => {
-          const { image, tolerance } = colorMap[hex];
-          const targetColor = hexToRgb(hex);
-          if (isColorClose(r, g, b, targetColor, tolerance)) {
-            matchedImage = image;
-          }
-        });
-        setSeatImage(matchedImage);
+        
+        if (seatImage === defaultStadium) {
+          // Default 상태에서 클릭한 경우
+          let matchedImage = defaultStadium;
+          Object.keys(colorMap).forEach((hex) => {
+            const { image, tolerance } = colorMap[hex];
+            const targetColor = hexToRgb(hex);
+            if (isColorClose(r, g, b, targetColor, tolerance)) {
+              matchedImage = image;
+            }
+          });
+          setSeatImage(matchedImage);
+        } else {
+          // ColorMap 상태에서 클릭한 경우 Default로 되돌림
+          setSeatImage(defaultStadium);
+        }
       }
     }
   };
-
+  //
   return (
     <div className="flex justify-center mt-6" onClick={() => setSeatImage(defaultStadium)}>
       <canvas
         ref={canvasRef}
-        className="max-w-[366px] w-full mx-auto"
+        className="max-w-[343px] w-full mx-auto"
         onClick={handleCanvasClick}
       />
     </div>

--- a/src/pages/Main/components/KtwizSeat.tsx
+++ b/src/pages/Main/components/KtwizSeat.tsx
@@ -15,6 +15,7 @@ import genieZoneSeat from "../../../assets/webp/seat/kt_geniezone.webp";
 import excitingSeat from "../../../assets/webp/seat/kt_exciting.webp";
 import outfieldSeat from "../../../assets/webp/seat/kt_outfield.webp";
 import tvingSeat from "../../../assets/webp/seat/kt_tving.webp";
+import { ScreenSize } from "@/src/constants/ReactionData"
 
 // 각 색상별 이미지와 오차값 포함
 const colorMap: { [key: string]: { image: StaticImageData; tolerance: number } } = {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

작업한 내용과 관련된 **Issue Number**를 작성해주세요.

#49

## ✅ PR 유형

어떤 **변경 사항**이 있었나요?

- [x] 새로운 기능 추가
- [x] 디자인 추가 및 수정
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💻 작업 내용

이번 PR에서 작업한 내용에 대해 설명해주세요.
- 이번 이슈 목표:
  - 모든 폰 기종, 웹에서 야구장 좌석 클릭 잘 되게
  - 이미지 변경 이벤트 동작 잘 되게

#### [Main.tsx]
- 메인홈 반응형 기본 레이아웃 구축
   - 메인홈에서 잠실, KT 컴포넌트에 화면 너비값을 props로 전달하도록 로직 수정

#### [ReactionData.ts]
- 반응형 관련 전역 데이터 (변수, 함수) 추가
   - (S) 360px 이하 야구장 이미지 반응형 로직을 만든다:  360px 기종 기준 디자인
   - (M) 360px 초과 400px 미만 야구장 이미지 반응형 로직을 만든다:  390px 기종 기준 디자인
   - (L) 400px 이상 야구장 이미지 반응형 로직을 만든다:  402px 기종 기준 디자인 (기존 크기)

#### [JamsilSeat.tsx]
- 화면 너비에 따른 야구장 이미지 크기 반응형으로 띄우기

#### [KtwizSeat.tsx]
- 화면 너비에 따른 야구장 이미지 크기 반응형으로 띄우기
- KT 좌석 이미지 잘 동작하도록 로직 수정
   - 메인홈 KT 컴포넌트에서 좌석 잘 눌리게 좌석 별 커스텀 오차값 크게 좀 더 크게 허용 (수정)
   - 메인홈 KT 컴포넌트에서 클릭한 좌석에서는 디폴트 KT 전체 좌석 이미지로만 넘어가도록 로직 수정
   - 클릭한 좌석 이미지A에서 다른 좌석 이미지A로 바로 넘어가지 못 하도록 제한



## 🖼️ 스크린샷

### 작은 폰 기종:  잠실, KT 반응형
- 320px 너비 폰

https://github.com/user-attachments/assets/28ac2d93-7c09-473d-ae15-b7edb6912795


### 일반 폰 기종:  잠실, KT 반응형
- 375px 너비 폰

https://github.com/user-attachments/assets/1cb05281-91ad-4031-97bc-3f8afd23c4cc

- 390px 너비 폰

https://github.com/user-attachments/assets/30f4a959-fbef-4828-8cdb-ea338728d716


### Pro 큰 폰 기종:  잠실, KT 반응형
- 430px 너비 폰

https://github.com/user-attachments/assets/356150dd-e383-4d8a-88b6-41d020de588c





## 🙏 리뷰 요구사항

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

ex) OO컴포넌트의 OO메소드명 검토 부탁드립니다.

## ✅ 체크리스트(PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
